### PR TITLE
Constrain python-telegram-bot version to 13.x to sidestep api changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-python-telegram-bot>=13.0
+python-telegram-bot~=13.0
 sqlalchemy>=1.3.20
 mysql-connector-python>=8.0.21


### PR DESCRIPTION
Hi, thanks for this awesome project!

The constraint `python-telegram-bot>=13.0` in `requirements.txt` currently resolves to `20.x` in the docker container environment, which it seems introduced some breaking changes (can no longer do `from telegram.ext import Dispatcher`).

I propose to change the constraint to `python-telegram-bot~=13.0`, which resolves to version `13.15` in the docker container environment. I haven't run all the tests with that version, but it seems to work and that is probably the version people have been using for a while.